### PR TITLE
Windmill Power Change

### DIFF
--- a/src/main/java/net/shadowmage/ancientwarfare/automation/tile/torque/multiblock/TileWindmillBlade.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/tile/torque/multiblock/TileWindmillBlade.java
@@ -13,6 +13,7 @@ import net.shadowmage.ancientwarfare.core.util.BlockPosition;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.lang.Math;
 
 public class TileWindmillBlade extends TileEntity {
 
@@ -49,7 +50,7 @@ public class TileWindmillBlade extends TileEntity {
         if (worldObj.isRemote) {
             updateRotation();
         } else if (isControl) {
-            energy = (windmillSize * windmillSize / 4.5) * AWAutomationStatics.windmill_per_size_output;
+            energy = Math.floor(windmillSize * windmillSize / 4.5) * AWAutomationStatics.windmill_per_size_output;
         }
     }
 

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/tile/torque/multiblock/TileWindmillBlade.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/tile/torque/multiblock/TileWindmillBlade.java
@@ -49,7 +49,7 @@ public class TileWindmillBlade extends TileEntity {
         if (worldObj.isRemote) {
             updateRotation();
         } else if (isControl) {
-            energy = windmillSize * AWAutomationStatics.windmill_per_size_output;
+            energy = (windmillSize * windmillSize / 4.5) * AWAutomationStatics.windmill_per_size_output;
         }
     }
 


### PR DESCRIPTION
Currently windmill power = length of blade square \* a config option
which doesn't exist (defaults to 1), which means that it is always best
to build min size windmills for all your power need. Changes power
output to be slightly more efficient than the same amount of min size
windmills. (12 min size windmills (which uses 11 more blocks than a max
size windmill) would make 60 power, with this change, one 17x17 windmill
would make 64ish power). The floor is needed to ensure this is true.
