### PR TITLE
Add "Upkeep location" config setting; improve upkeep order slip UX

### DIFF
--- a/src/main/java/net/shadowmage/ancientwarfare/npc/config/AWNPCStatics.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/config/AWNPCStatics.java
@@ -65,6 +65,7 @@ public class AWNPCStatics extends ModConfiguration {
     public static int npcXpFromMoveItem = 1;//TODO add to config
     public static int npcWorkTicks = 50;
     public static int npcDefaultUpkeepWithdraw = 6000;//5 minutes
+    public static boolean npcAllowUpkeepAnyInventory = true;
     public static int townMaxRange = 100;
     public static int townUpdateFreq = 100; //5 second broadcast frequency
     public static boolean exportEntityNames = false;
@@ -236,6 +237,10 @@ public class AWNPCStatics extends ModConfiguration {
                 "How many game ticks should pass between workers' processing work at a work-site.\n" +
                 "Lower values result in more work output, higher values result in less work output.").getInt();
 
+        npcAllowUpkeepAnyInventory = config.get(serverSettings, "allow_upkeep_any_inventory", npcAllowUpkeepAnyInventory, "Allow NPC upkeep location at any inventory\nDefault=" + npcAllowUpkeepAnyInventory + "\n" +
+                "By default, the Upkeep Order slip can be used to assign upkeep locations to any valid inventory block.\n" +
+                "If set to false, only Town Hall blocks will be allowed as valid upkeep locations.").getBoolean();
+        
         townMaxRange = config.get(serverSettings, "town_hall_max_range", townMaxRange, "Town Hall Max Activation Range\nDefault=" + townMaxRange + "\n" +
                 "How many blocks can a Town Hall be away from an NPC, while still detecting their death for possible resurrection.\n" +
                 "This is a maximum, for server efficiency sake. Lower individual values can be setup from each block interaction GUI.").getInt();

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/item/ItemUpkeepOrder.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/item/ItemUpkeepOrder.java
@@ -2,6 +2,7 @@ package net.shadowmage.ancientwarfare.npc.item;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.world.World;
 import net.shadowmage.ancientwarfare.core.network.NetworkHandler;
 import net.shadowmage.ancientwarfare.core.util.BlockPosition;
@@ -36,8 +37,9 @@ public class ItemUpkeepOrder extends ItemOrders {
             BlockPosition hit = BlockTools.getBlockClickedOn(player, player.worldObj, false);
             if (upkeepOrder.addUpkeepPosition(player.worldObj, hit)) {
                 upkeepOrder.write(stack);
-            }
-            NetworkHandler.INSTANCE.openGui(player, NetworkHandler.GUI_NPC_UPKEEP_ORDER, 0, 0, 0);
+                player.addChatComponentMessage(new ChatComponentTranslation("guistrings.npc.upkeep_point_set"));
+            } else 
+                NetworkHandler.INSTANCE.openGui(player, NetworkHandler.GUI_NPC_UPKEEP_ORDER, 0, 0, 0);
         }
     }
 

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/orders/UpkeepOrder.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/orders/UpkeepOrder.java
@@ -8,6 +8,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
 import net.shadowmage.ancientwarfare.core.interfaces.INBTSerialable;
 import net.shadowmage.ancientwarfare.core.util.BlockPosition;
+import net.shadowmage.ancientwarfare.npc.block.BlockTownHall;
+import net.shadowmage.ancientwarfare.npc.config.AWNPCStatics;
 import net.shadowmage.ancientwarfare.npc.item.ItemUpkeepOrder;
 
 public class UpkeepOrder implements INBTSerialable {
@@ -65,6 +67,8 @@ public class UpkeepOrder implements INBTSerialable {
 
     public boolean addUpkeepPosition(World world, BlockPosition pos) {
         if(pos != null && world.getTileEntity(pos.x, pos.y, pos.z) instanceof IInventory) {
+            if (!AWNPCStatics.npcAllowUpkeepAnyInventory && (!(world.getBlock(pos.x, pos.y, pos.z) instanceof BlockTownHall)))
+                return false;
             upkeepPosition = pos;
             upkeepDimension = world.provider.dimensionId;
             blockSide = 0;

--- a/src/main/resources/assets/ancientwarfare/lang/en_US.lang
+++ b/src/main/resources/assets/ancientwarfare/lang/en_US.lang
@@ -386,6 +386,7 @@ guistrings.npc.remove_upkeep_point=Remove
 guistrings.npc.side_change=Side
 guistrings.npc.upkeep_time=Upkeep Time
 guistrings.npc.assign_upkeep_point=Please Assign An Upkeep Point
+guistrings.npc.upkeep_point_set=Upkeep Point set.
 guistrings.npc.remove_work_point=Remove
 guistrings.npc.work_length=Work Time
 guistrings.npc.work_priority.site_need=Find Next Work


### PR DESCRIPTION
By default, Upkeep orders can be assigned to any valid block (i.e. any inventory). Setting this to false will only allow Town Hall blocks as valid upkeep locations.

Requested by @Dulciphi for raid-mechanic gameplay (in this style of gameplay, raiding mobs are set to only target town hall blocks).

Also: Make Upkeep Order UX a bit friendlier. Will give a chat message if the upkeep point is set successfully, else open the GUI (instead of just opening the GUI every time, which incorrectly shows the old upkeep point in the event of it being changed).
