### PR TITLE
Add "alarm" feature to Town Hall

### DIFF
--- a/src/main/java/net/shadowmage/ancientwarfare/npc/ai/owned/NpcAIPlayerOwnedAlarmResponse.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/ai/owned/NpcAIPlayerOwnedAlarmResponse.java
@@ -1,0 +1,67 @@
+package net.shadowmage.ancientwarfare.npc.ai.owned;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
+import net.shadowmage.ancientwarfare.core.util.BlockPosition;
+import net.shadowmage.ancientwarfare.npc.ai.NpcAI;
+import net.shadowmage.ancientwarfare.npc.entity.NpcPlayerOwned;
+import net.shadowmage.ancientwarfare.npc.tile.TileTownHall;
+
+public class NpcAIPlayerOwnedAlarmResponse extends NpcAI<NpcPlayerOwned> {
+
+    public NpcAIPlayerOwnedAlarmResponse(NpcPlayerOwned npc) {
+        super(npc);
+        this.setMutexBits(ATTACK + MOVE);
+    }
+
+    @Override
+    public boolean shouldExecute() {
+        if (!npc.getIsAIEnabled()) {
+            return false;
+        }
+        return npc.getUpkeepPoint() != null && npc.getUpkeepDimensionId() == npc.worldObj.provider.dimensionId && npc.isAlarmed;
+    }
+    
+    @Override
+    public boolean continueExecuting() {
+        if (!npc.getIsAIEnabled()) {
+            return false;
+        }
+        return npc.getUpkeepPoint() != null && npc.getUpkeepDimensionId() == npc.worldObj.provider.dimensionId && npc.isAlarmed;
+    }
+
+    /**
+     * Execute a one shot task or start executing a continuous task
+     */
+    @Override
+    public void startExecuting() {
+        npc.addAITask(TASK_GO_HOME);
+    }
+    
+    /**
+     * Updates the task
+     */
+    @Override
+    public void updateTask() {
+        BlockPosition pos = npc.getUpkeepPoint();
+        if (pos == null) {
+            return;
+        }
+        double dist = npc.getDistanceSq(pos.x + 0.5d, pos.y, pos.z + 0.5d);
+        if (dist > ACTION_RANGE) {
+            npc.addAITask(TASK_MOVE);
+            moveToPosition(pos, dist);
+        } else {
+            npc.removeAITask(TASK_MOVE);
+        }
+    }
+    
+    /**
+     * Resets the task
+     */
+    @Override
+    public void resetTask() {
+        moveRetryDelay = 0;
+        npc.removeAITask(TASK_GO_HOME + TASK_MOVE);
+    }
+}

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/block/BlockTownHall.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/block/BlockTownHall.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
@@ -87,5 +88,19 @@ public class BlockTownHall extends Block implements IRotatableBlock {
         TileEntity te = world.getTileEntity(x, y, z);
         return te instanceof IInteractableTile && ((IInteractableTile) te).onBlockClicked(player);
     }
-
+    
+    /**
+     * Lets the block know when one of its neighbor changes. Doesn't know which neighbor changed (coordinates passed are
+     * their own) Args: x, y, z, neighbor Block
+     */
+    @Override
+    public void onNeighborBlockChange(World world, int x, int y, int z, Block block) {
+        if (!world.isRemote) {
+            TileTownHall tileTownHall = (TileTownHall) world.getTileEntity(x, y, z);
+            if (world.isBlockIndirectlyGettingPowered(x, y, z))
+                tileTownHall.alarmActive = true;
+            else
+                tileTownHall.alarmActive = false;
+        }
+    }
 }

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcBard.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcBard.java
@@ -12,10 +12,7 @@ import net.shadowmage.ancientwarfare.core.interfaces.ISinger;
 import net.shadowmage.ancientwarfare.core.network.NetworkHandler;
 import net.shadowmage.ancientwarfare.core.util.SongPlayData;
 import net.shadowmage.ancientwarfare.npc.ai.*;
-import net.shadowmage.ancientwarfare.npc.ai.owned.NpcAIPlayerOwnedFollowCommand;
-import net.shadowmage.ancientwarfare.npc.ai.owned.NpcAIPlayerOwnedGetFood;
-import net.shadowmage.ancientwarfare.npc.ai.owned.NpcAIPlayerOwnedIdleWhenHungry;
-import net.shadowmage.ancientwarfare.npc.ai.owned.NpcAIPlayerOwnedRideHorse;
+import net.shadowmage.ancientwarfare.npc.ai.owned.*;
 
 public class NpcBard extends NpcPlayerOwned implements ISinger {
 
@@ -30,6 +27,7 @@ public class NpcBard extends NpcPlayerOwned implements ISinger {
         this.tasks.addTask(2, new NpcAIFollowPlayer(this));
         this.tasks.addTask(2, new NpcAIPlayerOwnedFollowCommand(this));
         this.tasks.addTask(3, new NpcAIFleeHostiles(this));
+        this.tasks.addTask(3, new NpcAIPlayerOwnedAlarmResponse(this));
         this.tasks.addTask(4, new NpcAIPlayerOwnedGetFood(this));
         this.tasks.addTask(5, new NpcAIPlayerOwnedIdleWhenHungry(this));
 

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcCombat.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcCombat.java
@@ -44,6 +44,7 @@ public class NpcCombat extends NpcPlayerOwned implements IRangedAttackMob {
         this.tasks.addTask(0, (horseAI = new NpcAIPlayerOwnedRideHorse(this)));
         this.tasks.addTask(2, new NpcAIFollowPlayer(this));
         this.tasks.addTask(2, new NpcAIPlayerOwnedFollowCommand(this));
+        this.tasks.addTask(3, new NpcAIPlayerOwnedAlarmResponse(this));
         this.tasks.addTask(4, new NpcAIPlayerOwnedGetFood(this));
         this.tasks.addTask(5, new NpcAIPlayerOwnedIdleWhenHungry(this));
         //6--empty....

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcCourier.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcCourier.java
@@ -29,6 +29,7 @@ public class NpcCourier extends NpcPlayerOwned {
         this.tasks.addTask(2, new NpcAIFollowPlayer(this));
         this.tasks.addTask(2, new NpcAIPlayerOwnedFollowCommand(this));
         this.tasks.addTask(3, new NpcAIFleeHostiles(this));
+        this.tasks.addTask(3, new NpcAIPlayerOwnedAlarmResponse(this));
         this.tasks.addTask(4, new NpcAIPlayerOwnedGetFood(this));
         this.tasks.addTask(5, new NpcAIPlayerOwnedIdleWhenHungry(this));
         this.tasks.addTask(6, (courierAI = new NpcAIPlayerOwnedCourier(this)));

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcPlayerOwned.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcPlayerOwned.java
@@ -113,11 +113,8 @@ public abstract class NpcPlayerOwned extends NpcBase implements IKeepFood{
                 upkeepAutoBlock = position;
             }
         }
-        // check for active alarm
-        if (getTownHall().alarmActive)
-            isAlarmed = true;
-        else
-            isAlarmed = false;
+        // (un)set alarmed status
+        isAlarmed = getTownHall().alarmActive;
     }
 
     private boolean validateTownHallPosition() {

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcPlayerOwned.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcPlayerOwned.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 public abstract class NpcPlayerOwned extends NpcBase implements IKeepFood{
 
+    public boolean isAlarmed = false;
+    
     private Command playerIssuedCommand;//TODO load/save
     private int foodValueRemaining = 0;
 
@@ -111,6 +113,11 @@ public abstract class NpcPlayerOwned extends NpcBase implements IKeepFood{
                 upkeepAutoBlock = position;
             }
         }
+        // check for active alarm
+        if (getTownHall().alarmActive)
+            isAlarmed = true;
+        else
+            isAlarmed = false;
     }
 
     private boolean validateTownHallPosition() {

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcPriest.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcPriest.java
@@ -22,6 +22,7 @@ public class NpcPriest extends NpcPlayerOwned {
         this.tasks.addTask(2, new NpcAIFollowPlayer(this));
         this.tasks.addTask(2, new NpcAIPlayerOwnedFollowCommand(this));
         this.tasks.addTask(3, new NpcAIFleeHostiles(this));
+        this.tasks.addTask(3, new NpcAIPlayerOwnedAlarmResponse(this));
         this.tasks.addTask(4, new NpcAIPlayerOwnedGetFood(this));
         this.tasks.addTask(5, new NpcAIPlayerOwnedIdleWhenHungry(this));
         this.tasks.addTask(6, new NpcAIMoveHome(this, 50F, 8F, 30F, 3F));

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcTrader.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcTrader.java
@@ -35,6 +35,7 @@ public class NpcTrader extends NpcPlayerOwned {
         this.tasks.addTask(2, new NpcAIFollowPlayer(this));
         this.tasks.addTask(2, new NpcAIPlayerOwnedFollowCommand(this));
         this.tasks.addTask(3, new NpcAIFleeHostiles(this));
+        this.tasks.addTask(3, new NpcAIPlayerOwnedAlarmResponse(this));
         this.tasks.addTask(4, tradeAI = new NpcAIPlayerOwnedTrader(this));
         this.tasks.addTask(5, new NpcAIPlayerOwnedGetFood(this));
         this.tasks.addTask(6, new NpcAIPlayerOwnedIdleWhenHungry(this));

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcWorker.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcWorker.java
@@ -42,6 +42,7 @@ public class NpcWorker extends NpcPlayerOwned implements IWorker {
         this.tasks.addTask(2, new NpcAIFollowPlayer(this));
         this.tasks.addTask(2, new NpcAIPlayerOwnedFollowCommand(this));
         this.tasks.addTask(3, new NpcAIFleeHostiles(this));
+        this.tasks.addTask(3, new NpcAIPlayerOwnedAlarmResponse(this));
         this.tasks.addTask(4, new NpcAIPlayerOwnedGetFood(this));
         this.tasks.addTask(5, new NpcAIPlayerOwnedIdleWhenHungry(this));
         this.tasks.addTask(6, (workAI = new NpcAIPlayerOwnedWork(this)));

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/tile/TileTownHall.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/tile/TileTownHall.java
@@ -110,6 +110,8 @@ public class TileTownHall extends TileOwned implements IInventory, IInteractable
         if(tag.hasKey("range")){
             setRange(tag.getInteger("range"));
         }
+        if (tag.hasKey("alarmActive"))
+            alarmActive = (tag.getBoolean("alarmActive"));
     }
 
     @Override
@@ -122,6 +124,7 @@ public class TileTownHall extends TileOwned implements IInventory, IInteractable
         }
         tag.setTag("deathNotices", entryList);
         tag.setInteger("range", broadcastRange);
+        tag.setBoolean("alarmActive", alarmActive);
     }
 
     @Override

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/tile/TileTownHall.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/tile/TileTownHall.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 public class TileTownHall extends TileOwned implements IInventory, IInteractableTile {
 
+    public boolean alarmActive = false;
+    
     private int broadcastRange = 80;
     private int updateDelayTicks = 0;
 


### PR DESCRIPTION
(Just making a new clean PR for this one)

If a redstone signal is sent to the Town Hall (indirectly, i.e. vanilla style) then all NPC's within the broadcast range of that town center will be ordered to return to their respective home. Upon redstone signal disabled, an "all clear" is broadcast.

A highly wanted feature of myself and @Dulciphi so third-party mods can declare a "disaster mode", for example the Tornado Sensor in Weather2 mod and DecoCraft's Fire Alarm.
