### PR TITLE
Warehouse UI updates & various fixes and improvements

### DIFF
--- a/src/main/java/net/shadowmage/ancientwarfare/automation/block/BlockFlywheelStorage.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/block/BlockFlywheelStorage.java
@@ -22,6 +22,7 @@ public class BlockFlywheelStorage extends Block {
 
     public BlockFlywheelStorage(String regName) {
         super(Material.rock);
+        this.setHardness(2.f);
         this.setBlockName(regName);
         this.setCreativeTab(AWAutomationItemLoader.automationTab);
     }

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/block/BlockWindmillBlade.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/block/BlockWindmillBlade.java
@@ -5,7 +5,9 @@ import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
@@ -13,12 +15,15 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.shadowmage.ancientwarfare.automation.item.AWAutomationItemLoader;
 import net.shadowmage.ancientwarfare.automation.tile.torque.multiblock.TileWindmillBlade;
+import net.shadowmage.ancientwarfare.core.item.ItemHammer;
 
 public class BlockWindmillBlade extends Block {
 
     public BlockWindmillBlade(String regName) {
-        super(Material.rock);
+        super(Material.wood);
         this.setBlockName(regName);
+        this.setHardness(1.f);
+        this.setHarvestLevel("axe", 1);
         this.setCreativeTab(AWAutomationItemLoader.automationTab);
     }
 
@@ -64,14 +69,14 @@ public class BlockWindmillBlade extends Block {
     public void onPostBlockPlaced(World world, int x, int y, int z, int meta) {
         super.onPostBlockPlaced(world, x, y, z, meta);
         TileWindmillBlade te = (TileWindmillBlade) world.getTileEntity(x, y, z);
-        te.blockPlaced();
+        //te.blockPlaced();
     }
 
     @Override
     public void breakBlock(World world, int x, int y, int z, Block block, int face) {
         TileWindmillBlade te = (TileWindmillBlade) world.getTileEntity(x, y, z);
+        te.blockBroken(); // Need to be called here to find and invalidate the entire mill 
         super.breakBlock(world, x, y, z, block, face);
-        te.blockBroken();//have to call post block-break so that the tile properly sees the block/tile as gone
     }
 
     @Override
@@ -84,4 +89,14 @@ public class BlockWindmillBlade extends Block {
         return true;
     }
 
+    @Override
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float fx, float fy, float fz) {
+        ItemStack held = player.getHeldItem();
+        if (held != null && held.getItem() instanceof ItemHammer) {
+            TileWindmillBlade te = (TileWindmillBlade) world.getTileEntity(x, y, z);
+            te.blockPlaced();
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/container/ContainerWarehouseControl.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/container/ContainerWarehouseControl.java
@@ -57,7 +57,7 @@ public class ContainerWarehouseControl extends ContainerTileBase<TileWarehouseBa
             if (reqTag.hasKey("reqItem")) {
                 item = ItemStack.loadItemStackFromNBT(reqTag.getCompoundTag("reqItem"));
             }
-            tileEntity.handleSlotClick(player, item, reqTag.getBoolean("isShiftClick"));
+            tileEntity.handleSlotClick(player, item, reqTag.getBoolean("isShiftClick"), reqTag.getBoolean("isRightClick"));
         }
         else if (tag.hasKey("changeList")) {
             handleChangeList(tag.getTagList("changeList", Constants.NBT.TAG_COMPOUND));
@@ -69,12 +69,13 @@ public class ContainerWarehouseControl extends ContainerTileBase<TileWarehouseBa
         refreshGui();
     }
 
-    public void handleClientRequestSpecific(ItemStack stack, boolean isShiftClick) {
+    public void handleClientRequestSpecific(ItemStack stack, boolean isShiftClick, boolean isRightClick) {
         NBTTagCompound tag = new NBTTagCompound();
         if (stack != null) {
             tag.setTag("reqItem", stack.writeToNBT(new NBTTagCompound()));
         }
         tag.setBoolean("isShiftClick", isShiftClick);
+        tag.setBoolean("isRightClick", isRightClick);
         NBTTagCompound pktTag = new NBTTagCompound();
         pktTag.setTag("slotClick", tag);
         sendDataToServer(pktTag);

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/container/ContainerWarehouseStorage.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/container/ContainerWarehouseStorage.java
@@ -49,12 +49,13 @@ public class ContainerWarehouseStorage extends ContainerTileBase<TileWarehouseSt
         return null;
     }
 
-    public void handleClientRequestSpecific(ItemStack stack, boolean isShiftClick) {
+    public void handleClientRequestSpecific(ItemStack stack, boolean isShiftClick, boolean isRightClick) {
         NBTTagCompound tag = new NBTTagCompound();
         if (stack != null) {
             tag.setTag("reqItem", stack.writeToNBT(new NBTTagCompound()));
         }
         tag.setBoolean("isShiftClick", isShiftClick);
+        tag.setBoolean("isRightClick", isRightClick);
         NBTTagCompound pktTag = new NBTTagCompound();
         pktTag.setTag("slotClick", tag);
         sendDataToServer(pktTag);
@@ -90,7 +91,7 @@ public class ContainerWarehouseStorage extends ContainerTileBase<TileWarehouseSt
             if (reqTag.hasKey("reqItem")) {
                 item = ItemStack.loadItemStackFromNBT(reqTag.getCompoundTag("reqItem"));
             }
-            tileEntity.handleSlotClick(player, item, reqTag.getBoolean("isShiftClick"));
+            tileEntity.handleSlotClick(player, item, reqTag.getBoolean("isShiftClick"), reqTag.getBoolean("isRightClick"));
         }
         else if (tag.hasKey("changeList")) {
             handleChangeList(tag.getTagList("changeList", Constants.NBT.TAG_COMPOUND));

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseControl.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseControl.java
@@ -83,7 +83,7 @@ public class GuiWarehouseControl extends GuiContainerBase<ContainerWarehouseCont
             @Override
             public boolean onEvent(GuiElement widget, ActivationEvent evt) {
                 if (evt.mButton == 0 && widget.isMouseOverElement(evt.mx, evt.my) && !area.isMouseOverSubElement(evt.mx, evt.my)) {
-                    getContainer().handleClientRequestSpecific(null, isShiftKeyDown());
+                    getContainer().handleClientRequestSpecific(null, isShiftKeyDown(), false);
                 }
                 return true;
             }
@@ -127,8 +127,11 @@ public class GuiWarehouseControl extends GuiContainerBase<ContainerWarehouseCont
         for (ItemStack displayStack : displayStacks) {
             slot = new ItemSlot(4 + x * 18, 3 + y * 18, displayStack, this) {
                 @Override
-                public void onSlotClicked(ItemStack stack) {
-                    getContainer().handleClientRequestSpecific(getStack(), isShiftKeyDown());
+                public void onSlotClicked(ItemStack stack, boolean rightClicked) {
+                    ItemStack reqStack = getStack();
+                    if (!(rightClicked && isShiftKeyDown()) && (reqStack != null) && (stack != null) && (reqStack.isItemEqual(stack) && ItemStack.areItemStackTagsEqual(stack, reqStack)))
+                        reqStack = null;
+                    getContainer().handleClientRequestSpecific(reqStack, isShiftKeyDown(), rightClicked);
                 }
             };
             area.addGuiElement(slot);

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseControl.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseControl.java
@@ -64,11 +64,22 @@ public class GuiWarehouseControl extends GuiContainerBase<ContainerWarehouseCont
                 }
             }
         };
+        Listener l = new Listener(Listener.MOUSE_UP) {
+            @Override
+            public boolean onEvent(GuiElement widget, ActivationEvent evt) {
+                if (evt.mButton == 1) {
+                    ((Text) widget).setText("");
+                    refreshGui();
+                }
+                return false;
+            }
+        };
+        input.addNewListener(l);
         addGuiElement(input);
 
         area = new CompositeItemSlots(this, 0, 8 + 12 + 4 + 12 + 2, 178, 96, this);
 
-        Listener l = new Listener(Listener.MOUSE_DOWN) {
+        l = new Listener(Listener.MOUSE_DOWN) {
             @Override
             public boolean onEvent(GuiElement widget, ActivationEvent evt) {
                 if (evt.mButton == 0 && widget.isMouseOverElement(evt.mx, evt.my) && !area.isMouseOverSubElement(evt.mx, evt.my)) {

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseControl.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseControl.java
@@ -67,7 +67,7 @@ public class GuiWarehouseControl extends GuiContainerBase<ContainerWarehouseCont
         Listener l = new Listener(Listener.MOUSE_UP) {
             @Override
             public boolean onEvent(GuiElement widget, ActivationEvent evt) {
-                if (evt.mButton == 1) {
+                if (evt.mButton == 1 && widget.isMouseOverElement(evt.mx, evt.my)) {
                     ((Text) widget).setText("");
                     refreshGui();
                 }

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseInterface.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseInterface.java
@@ -111,7 +111,7 @@ public class GuiWarehouseInterface extends GuiContainerBase<ContainerWarehouseIn
         }
 
         @Override
-        public void onSlotClicked(ItemStack stack) {
+        public void onSlotClicked(ItemStack stack, boolean rightClicked) {
             ItemStack in = stack == null ? null : stack.copy();
             this.setItem(in);
             if (in != null) {

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseStockViewer.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseStockViewer.java
@@ -97,7 +97,7 @@ public class GuiWarehouseStockViewer extends GuiContainerBase<ContainerWarehouse
         }
 
         @Override
-        public void onSlotClicked(ItemStack stack) {
+        public void onSlotClicked(ItemStack stack, boolean rightClicked) {
             ItemStack in = stack == null ? null : stack.copy();
             this.setItem(in);
             if (in != null) {

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseStorage.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/gui/GuiWarehouseStorage.java
@@ -33,7 +33,7 @@ public class GuiWarehouseStorage extends GuiContainerBase<ContainerWarehouseStor
             @Override
             public boolean onEvent(GuiElement widget, ActivationEvent evt) {
                 if (evt.mButton == 0 && widget.isMouseOverElement(evt.mx, evt.my) && !area2.isMouseOverSubElement(evt.mx, evt.my)) {
-                    getContainer().handleClientRequestSpecific(null, isShiftKeyDown());
+                    getContainer().handleClientRequestSpecific(null, isShiftKeyDown(), false);
                 }
                 return true;
             }
@@ -105,8 +105,11 @@ public class GuiWarehouseStorage extends GuiContainerBase<ContainerWarehouseStor
         for (ItemStack displayStack : displayStacks) {
             slot = new ItemSlot(4 + x * 18, 8 + y * 18, displayStack, this) {
                 @Override
-                public void onSlotClicked(ItemStack stack) {
-                    getContainer().handleClientRequestSpecific(getStack(), isShiftKeyDown());
+                public void onSlotClicked(ItemStack stack, boolean rightClicked) {
+                    ItemStack reqStack = getStack();
+                    if (!(rightClicked && isShiftKeyDown()) && (reqStack != null) && (stack != null) && (reqStack.isItemEqual(stack) && ItemStack.areItemStackTagsEqual(stack, reqStack)))
+                        reqStack = null;
+                    getContainer().handleClientRequestSpecific(reqStack, isShiftKeyDown(), rightClicked);
                 }
             };
             area2.addGuiElement(slot);
@@ -145,7 +148,7 @@ public class GuiWarehouseStorage extends GuiContainerBase<ContainerWarehouseStor
         }
 
         @Override
-        public void onSlotClicked(ItemStack stack) {
+        public void onSlotClicked(ItemStack stack, boolean rightClicked) {
             ItemStack in = stack == null ? null : stack.copy();
             this.setItem(in);
             if (in != null) {

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/tile/torque/multiblock/TileWindmillBlade.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/tile/torque/multiblock/TileWindmillBlade.java
@@ -68,8 +68,25 @@ public class TileWindmillBlade extends TileEntity {
     }
 
     public void blockBroken() {
-        if(!worldObj.isRemote)
-        informNeighborsToValidate();
+        if ((!worldObj.isRemote) && (this.controlPos != null)) {
+            BlockPosition controller = controlPos.copy();
+            TileWindmillBlade controllerTE = isControl?this:(TileWindmillBlade) worldObj.getTileEntity(controlPos.x, controlPos.y, controlPos.z);
+            int dY = controllerTE.windmillSize/2;
+            int dX = (controllerTE.windmillDirection == 4)?0:dY;
+            int dZ = (controllerTE.windmillDirection == 2)?0:dY;
+            for(int x = controller.x - dX; x <= controller.x + dX; x++){
+                for(int y = controller.y - dY; y <= controller.y + dY; y++){
+                    for(int z = controller.z - dZ; z <= controller.z + dZ; z++){
+                        TileEntity te = worldObj.getTileEntity(x, y, z);
+                        if (te instanceof TileWindmillBlade) {
+                            TileWindmillBlade tb = (TileWindmillBlade) te;
+                            if (tb.controlPos != null && tb.controlPos.equals(controller))
+                                ((TileWindmillBlade) te).setController(null);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     public TileWindmillBlade getMaster() {

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/tile/warehouse2/IWarehouseStorageTile.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/tile/warehouse2/IWarehouseStorageTile.java
@@ -31,7 +31,7 @@ public interface IWarehouseStorageTile {
 
     public void removeViewer(ContainerWarehouseStorage containerWarehouseStorage);
 
-    public void handleSlotClick(EntityPlayer player, ItemStack item, boolean isShiftClick);
+    public void handleSlotClick(EntityPlayer player, ItemStack item, boolean isShiftClick, boolean isRightClick);
 
     public ItemStack tryAdd(ItemStack stack);
 

--- a/src/main/java/net/shadowmage/ancientwarfare/automation/tile/warehouse2/TileWarehouseBase.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/automation/tile/warehouse2/TileWarehouseBase.java
@@ -100,7 +100,7 @@ public abstract class TileWarehouseBase extends TileWorksiteBounded implements I
         return 3;
     }
 
-    public abstract void handleSlotClick(EntityPlayer player, ItemStack filter, boolean shiftClick);
+    public abstract void handleSlotClick(EntityPlayer player, ItemStack filter, boolean shiftClick, boolean rightClick);
 
     public void changeCachedQuantity(ItemStack filter, int change) {
         if (change > 0) {

--- a/src/main/java/net/shadowmage/ancientwarfare/core/gui/GuiContainerBase.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/core/gui/GuiContainerBase.java
@@ -320,8 +320,8 @@ public abstract class GuiContainerBase<T extends ContainerBase> extends GuiConta
         /**
          * the mouse button number.
          * -1 = none
-         * 0 = RMB
-         * 1 = LMB
+         * 0 = LMB
+         * 1 = RMB
          * 2+= ?
          */
         public int mButton;

--- a/src/main/java/net/shadowmage/ancientwarfare/core/gui/GuiResearchBook.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/core/gui/GuiResearchBook.java
@@ -175,7 +175,7 @@ public class GuiResearchBook extends GuiContainerBase {
         }
 
         @Override
-        public void onSlotClicked(ItemStack stack) {
+        public void onSlotClicked(ItemStack stack, boolean rightClicked) {
             selectedRecipe = researched;
             researchMode = false;
             refreshGui();

--- a/src/main/java/net/shadowmage/ancientwarfare/core/gui/elements/ItemSlot.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/core/gui/elements/ItemSlot.java
@@ -41,7 +41,7 @@ public class ItemSlot extends GuiElement {
             public boolean onEvent(GuiElement widget, ActivationEvent evt) {
                 if (widget.isMouseOverElement(evt.mx, evt.my)) {
                     ItemStack stack = Minecraft.getMinecraft().thePlayer.inventory.getItemStack();
-                    onSlotClicked(stack);
+                    onSlotClicked(stack, evt.mButton == 1);
                 }
                 return true;
             }
@@ -185,7 +185,7 @@ public class ItemSlot extends GuiElement {
         GL11.glPopMatrix();
     }
 
-    public void onSlotClicked(ItemStack stack) {
+    public void onSlotClicked(ItemStack stack, boolean rightClicked) {
 
     }
 

--- a/src/main/java/net/shadowmage/ancientwarfare/core/util/InventoryTools.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/core/util/InventoryTools.java
@@ -697,13 +697,15 @@ public class InventoryTools {
 
         @Override
         public int compare(ItemStack o1, ItemStack o2) {
-            int val;
+            int val = 0;
             if(!textInput.isEmpty()) {
                 val = compareViaTextInput(o1, o2);
-            }else{
-                val = sortType.compare(o1, o2);
             }
-            return val * sortOrder.mult;
+            
+            if (val == 0){
+                val = sortType.compare(o1, o2) * sortOrder.mult;
+            }
+            return val;
         }
 
         private int compareViaTextInput(ItemStack o1, ItemStack o2) {
@@ -711,16 +713,16 @@ public class InventoryTools {
             String n1 = o1.getDisplayName().toLowerCase(Locale.ENGLISH), n2 = o2.getDisplayName().toLowerCase(Locale.ENGLISH);
             if (n1.startsWith(input)){
                 if(!n2.startsWith(input))
-                    return 1;
+                    return -1;
             } else if (n2.startsWith(input)) {
-                return -1;
+                return 1;
             } else if (n1.contains(input)){
                 if(!n2.contains(input))
-                    return 1;
+                    return -1;
             } else if (n2.contains(input)) {
-                return -1;
+                return 1;
             }
-            return sortType.compare(o1, o2);
+            return 0;
         }
     }
 

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/gui/GuiNpcFactionTradeSetup.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/gui/GuiNpcFactionTradeSetup.java
@@ -144,7 +144,7 @@ public class GuiNpcFactionTradeSetup extends GuiContainerBase<ContainerNpcFactio
         stack = stack == null ? null : stack.copy();
         final ItemSlot slot = new ItemSlot(x, y, stack, this) {
             @Override
-            public void onSlotClicked(ItemStack stack) {
+            public void onSlotClicked(ItemStack stack, boolean rightClicked) {
                 stack = stack == null ? null : stack.copy();
                 setItem(stack);
                 trade.setInputStack(slotNum, stack);
@@ -162,7 +162,7 @@ public class GuiNpcFactionTradeSetup extends GuiContainerBase<ContainerNpcFactio
         stack = stack == null ? null : stack.copy();
         final ItemSlot slot = new ItemSlot(x, y, stack, this) {
             @Override
-            public void onSlotClicked(ItemStack stack) {
+            public void onSlotClicked(ItemStack stack, boolean rightClicked) {
                 stack = stack == null ? null : stack.copy();
                 setItem(stack);
                 trade.setOutputStack(slotNum, stack);

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/gui/GuiRoutingOrder.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/gui/GuiRoutingOrder.java
@@ -110,7 +110,7 @@ public class GuiRoutingOrder extends GuiContainerBase<ContainerRoutingOrder> {
             for (int i = 0; i < point.getFilterSize(); i++) {
                 slot = new IndexedRoutePointItemSlot(8 + i * 18, totalHeight + 10 + 12 + 2, point.getFilterInSlot(i), this, point, i) {
                     @Override
-                    public void onSlotClicked(ItemStack stack) {
+                    public void onSlotClicked(ItemStack stack, boolean rightClicked) {
                         onFilterSlotClicked(this, point, index, stack);
                     }
                 };

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/gui/GuiTradeOrder.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/gui/GuiTradeOrder.java
@@ -191,7 +191,7 @@ public class GuiTradeOrder extends GuiContainerBase<ContainerTradeOrder> {
         stack = stack == null ? null : stack.copy();
         final ItemSlot slot = new ItemSlot(x, y, stack, this) {
             @Override
-            public void onSlotClicked(ItemStack stack) {
+            public void onSlotClicked(ItemStack stack, boolean rightClicked) {
                 stack = stack == null ? null : stack.copy();
                 setItem(stack);
                 trade.setInputStack(slotNum, stack);
@@ -208,7 +208,7 @@ public class GuiTradeOrder extends GuiContainerBase<ContainerTradeOrder> {
         stack = stack == null ? null : stack.copy();
         final ItemSlot slot = new ItemSlot(x, y, stack, this) {
             @Override
-            public void onSlotClicked(ItemStack stack) {
+            public void onSlotClicked(ItemStack stack, boolean rightClicked) {
                 stack = stack == null ? null : stack.copy();
                 setItem(stack);
                 trade.setOutputStack(slotNum, stack);
@@ -384,7 +384,7 @@ public class GuiTradeOrder extends GuiContainerBase<ContainerTradeOrder> {
     private int addDepositEntry(final POTradeDepositEntry entry, final int index, int startHeight) {
         ItemSlot slot = new ItemSlot(8, startHeight, entry.getFilter(), this) {
             @Override
-            public void onSlotClicked(ItemStack stack) {
+            public void onSlotClicked(ItemStack stack, boolean rightClicked) {
                 stack = stack == null ? null : stack.copy();
                 entry.setFilter(stack);
                 setItem(stack);
@@ -419,7 +419,7 @@ public class GuiTradeOrder extends GuiContainerBase<ContainerTradeOrder> {
     private int addWithdrawEntry(final POTradeWithdrawEntry entry, final int index, int startHeight) {
         ItemSlot slot = new ItemSlot(8, startHeight, entry.getFilter(), this) {
             @Override
-            public void onSlotClicked(ItemStack stack) {
+            public void onSlotClicked(ItemStack stack, boolean rightClicked) {
                 stack = stack == null ? null : stack.copy();
                 entry.setFilter(stack);
                 setItem(stack);


### PR DESCRIPTION
A couple of user experience enhancements and (arguably) fixes for the warehouse UI.
- Fixes text search, results will always be at the top,  no matter the search order or type
- Enhancement: Right-click clears search text
- Enhancement: Right-clicking an item takes half a stack (also works for storage)
- Enhancement: Shift-right-click adds an item to the cursor if possible (also works for storage)
- Enhancement: Items can be put back into a slot with the same item (also works for storage)
