### PR TITLE
Allow NPCs to work in Twilight Forest Dimension

### DIFF
--- a/src/main/java/net/shadowmage/ancientwarfare/npc/AncientWarfareNPC.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/AncientWarfareNPC.java
@@ -23,6 +23,7 @@ import net.shadowmage.ancientwarfare.core.registry.RegistryLoader;
 import net.shadowmage.ancientwarfare.npc.command.CommandDebugAI;
 import net.shadowmage.ancientwarfare.npc.command.CommandFaction;
 import net.shadowmage.ancientwarfare.npc.compat.EpicSiegeCompat;
+import net.shadowmage.ancientwarfare.npc.compat.TwilightForestCompat;
 import net.shadowmage.ancientwarfare.npc.config.AWNPCStatics;
 import net.shadowmage.ancientwarfare.npc.container.ContainerCombatOrder;
 import net.shadowmage.ancientwarfare.npc.container.ContainerNpcBard;
@@ -46,7 +47,7 @@ import net.shadowmage.ancientwarfare.npc.registry.FactionRegistry;
 import net.shadowmage.ancientwarfare.npc.registry.NpcDefaultsRegistry;
 import org.apache.logging.log4j.Logger;
 
-@Mod(name = "Ancient Warfare NPCs", modid = AncientWarfareNPC.modID, version = "@VERSION@", dependencies = "required-after:ancientwarfare")
+@Mod(name = "Ancient Warfare NPCs", modid = AncientWarfareNPC.modID, version = "@VERSION@", dependencies = "required-after:ancientwarfare;after:twilightforest")
 
 public class AncientWarfareNPC {
 	public static final String modID = "ancientwarfarenpc";
@@ -96,6 +97,7 @@ public class AncientWarfareNPC {
 		PacketBase.registerPacketType(NetworkHandler.PACKET_FACTION_UPDATE, PacketFactionUpdate.class);
 
 		CompatLoader.registerCompat(new EpicSiegeCompat());
+		CompatLoader.registerCompat(new TwilightForestCompat());
 
 		RegistryLoader.registerParser(new FactionRegistry.FactionParser());
 		RegistryLoader.registerParser(new NpcDefaultsRegistry.FactionNpcDefaultsParser());

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/compat/TwilightForestCompat.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/compat/TwilightForestCompat.java
@@ -9,9 +9,6 @@ public class TwilightForestCompat implements ICompat {
     public String getModId() {
         return "twilightforest";
     }
-//1000
-//13000
-
 
     @Override
     public void init() {

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/compat/TwilightForestCompat.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/compat/TwilightForestCompat.java
@@ -1,0 +1,20 @@
+package net.shadowmage.ancientwarfare.npc.compat;
+
+import net.shadowmage.ancientwarfare.core.compat.ICompat;
+import net.shadowmage.ancientwarfare.npc.entity.NpcBase;
+import net.shadowmage.ancientwarfare.npc.shims.TwilightForestSleepShim;
+
+public class TwilightForestCompat implements ICompat {
+    @Override
+    public String getModId() {
+        return "twilightforest";
+    }
+//1000
+//13000
+
+
+    @Override
+    public void init() {
+        NpcBase.addSleepShim(new TwilightForestSleepShim());
+    }
+}

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcBase.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcBase.java
@@ -39,7 +39,6 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.ISpecialArmor;
 import net.minecraftforge.common.util.Constants;
-import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 import net.minecraftforge.fml.relauncher.Side;

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcBase.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcBase.java
@@ -39,6 +39,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.ISpecialArmor;
 import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 import net.minecraftforge.fml.relauncher.Side;
@@ -59,6 +60,7 @@ import net.shadowmage.ancientwarfare.npc.item.ItemCommandBaton;
 import net.shadowmage.ancientwarfare.npc.item.ItemNpcSpawner;
 import net.shadowmage.ancientwarfare.npc.item.ItemShield;
 import net.shadowmage.ancientwarfare.npc.registry.NpcDefaultsRegistry;
+import net.shadowmage.ancientwarfare.npc.shims.ISleepShim;
 import net.shadowmage.ancientwarfare.npc.skin.NpcSkinManager;
 import net.shadowmage.ancientwarfare.vehicle.entity.IPathableEntity;
 import net.shadowmage.ancientwarfare.vehicle.entity.VehicleBase;
@@ -103,6 +105,8 @@ public abstract class NpcBase extends EntityCreature implements IEntityAdditiona
 	private String followingPlayerName;//set/cleared onInteract from player if player.team==this.team
 
 	private NpcLevelingStats levelingStats;
+
+	private static List<ISleepShim> sleepShims = new ArrayList<>();
 
 	/*
 	 * a single base texture for ALL npcs to share, used in case other textures were not set
@@ -1305,7 +1309,16 @@ public abstract class NpcBase extends EntityCreature implements IEntityAdditiona
 	}
 
 	public boolean shouldSleep() {
-		return !world.isDaytime();
+		int votes;
+		if(!world.isDaytime()){
+				votes = 1;
+		}else{
+			votes = 0;
+		}
+		for (ISleepShim shim: sleepShims) {
+			votes += shim.shouldSleep(world,this);
+		}
+		return votes > 0;
 	}
 
 	// Only used by the renderer
@@ -1388,5 +1401,9 @@ public abstract class NpcBase extends EntityCreature implements IEntityAdditiona
 	@Override
 	public void onStuckDetected() {
 		//noop
+	}
+
+	public static void addSleepShim(ISleepShim shim){
+		sleepShims.add(shim);
 	}
 }

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/shims/ISleepShim.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/shims/ISleepShim.java
@@ -1,0 +1,8 @@
+package net.shadowmage.ancientwarfare.npc.shims;
+
+import net.minecraft.world.World;
+import net.shadowmage.ancientwarfare.npc.entity.NpcBase;
+
+public interface ISleepShim {
+    int shouldSleep(World world, NpcBase npc);
+}

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/shims/TwilightForestSleepShim.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/shims/TwilightForestSleepShim.java
@@ -1,0 +1,16 @@
+package net.shadowmage.ancientwarfare.npc.shims;
+
+import net.minecraft.world.World;
+import net.shadowmage.ancientwarfare.npc.entity.NpcBase;
+import twilightforest.TFConfig;
+
+public class TwilightForestSleepShim implements ISleepShim{
+    @Override
+    public int shouldSleep(World world, NpcBase npc) {
+        if(npc.dimension == TFConfig.dimension.dimensionID && (world.getWorldTime() < 1000 || world.getWorldTime() > 13000)){
+            return 0;
+        }else{
+            return -1;
+        }
+    }
+}


### PR DESCRIPTION
I'm sure changes will be desired, but this will allow NPCs to work in the Twilight Forest dimension (and possibly allow the addition of others)despite the Dim's always night setting, the voting system will allow shims(an interface that will probably get replaced) to oppose each other rather than a straight && vs || fight.