### PR TITLE
Urn harvest speed lowered from default

### DIFF
--- a/src/main/java/net/shadowmage/ancientwarfare/structure/block/BlockUrn.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/structure/block/BlockUrn.java
@@ -24,6 +24,7 @@ import java.util.Random;
 public class BlockUrn extends BlockBaseStructure {
 	public BlockUrn() {
 		super(Material.CIRCUITS, "urn");
+		setHardness(0.4F);
 	}
 
 	@Override


### PR DESCRIPTION
I think 0.4F or 0.3F would be ideal for this block so players can break it faster, but still not accidentally