### PR TITLE
only display the custom name of faction NPCs for vanilla events (e.g.…

### DIFF
--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/faction/NpcFaction.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/faction/NpcFaction.java
@@ -203,7 +203,7 @@ public abstract class NpcFaction extends NpcBase {
 		//noinspection deprecation
 		String name = I18n.translateToLocal("entity.ancientwarfarenpc." + getNpcFullType() + ".name");
 		if (hasCustomName()) {
-			name = name + " : " + getCustomNameTag();
+			name = getCustomNameTag();
 		}
 		return name;
 	}


### PR DESCRIPTION
… when they kill the player) instead of their original + custom name